### PR TITLE
Minor cleanups of TNT

### DIFF
--- a/src/main/java/org/dcsa/tnt/service/impl/EquipmentEventServiceImpl.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/EquipmentEventServiceImpl.java
@@ -20,11 +20,6 @@ public class EquipmentEventServiceImpl extends ExtendedBaseServiceImpl<Equipment
         return equipmentEventRepository;
     }
 
-    @Override
-    public Class<EquipmentEvent> getModelClass() {
-        return EquipmentEvent.class;
-    }
-
     //Overriding base method here, as it marks empty results as an error, meaning we can't use switchOnEmpty()
     @Override
     public Mono<EquipmentEvent> findById(UUID id) {

--- a/src/main/java/org/dcsa/tnt/service/impl/EventServiceImpl.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/EventServiceImpl.java
@@ -32,11 +32,6 @@ public class EventServiceImpl extends ExtendedBaseServiceImpl<EventRepository, E
     }
 
     @Override
-    public Class<Event> getModelClass() {
-        return Event.class;
-    }
-
-    @Override
     public Mono<Event> findById(UUID id) {
         return eventRepository.findById(UUID.randomUUID())
                 .switchIfEmpty(transportEventService.findById(id))

--- a/src/main/java/org/dcsa/tnt/service/impl/EventServiceImpl.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/EventServiceImpl.java
@@ -44,21 +44,21 @@ public class EventServiceImpl extends ExtendedBaseServiceImpl<EventRepository, E
     public Mono<Event> create(Event event) {
         switch (event.getEventType()) {
             case SHIPMENT:
-                return shipmentEventService.save((ShipmentEvent) event).doOnNext(
+                return shipmentEventService.create((ShipmentEvent) event).doOnNext(
                         e -> new EventCallbackHandler(
                                 eventSubscriptionRepository.findSubscriptionsByFilters(e.getEventType(),
                                         null), e)
                                 .start()
                 ).map(e -> e);
             case TRANSPORT:
-                return transportEventService.save((TransportEvent) event).doOnNext(
+                return transportEventService.create((TransportEvent) event).doOnNext(
                         e -> new EventCallbackHandler(
                                 eventSubscriptionRepository.findSubscriptionsByFilters(e.getEventType(),
                                         null), e)
                                 .start()
                 ).map(e -> e);
             case EQUIPMENT:
-                return equipmentEventService.save((EquipmentEvent) event).doOnNext(
+                return equipmentEventService.create((EquipmentEvent) event).doOnNext(
                         e -> new EventCallbackHandler(
                                 eventSubscriptionRepository.findSubscriptionsByFilters(e.getEventType(),
                                 e.getEquipmentReference()), e)

--- a/src/main/java/org/dcsa/tnt/service/impl/EventSubscriptionServiceImpl.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/EventSubscriptionServiceImpl.java
@@ -24,11 +24,6 @@ public class EventSubscriptionServiceImpl extends ExtendedBaseServiceImpl<EventS
     }
 
     @Override
-    public Class<EventSubscription> getModelClass() {
-        return EventSubscription.class;
-    }
-
-    @Override
     protected Mono<EventSubscription> preSaveHook(EventSubscription eventSubscription) {
         // Ensure that the callback url at least looks valid.
         try {

--- a/src/main/java/org/dcsa/tnt/service/impl/ShipmentEventServiceImpl.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/ShipmentEventServiceImpl.java
@@ -21,11 +21,6 @@ public class ShipmentEventServiceImpl extends ExtendedBaseServiceImpl<ShipmentEv
         return shipmentEventRepository;
     }
 
-    @Override
-    public Class<ShipmentEvent> getModelClass() {
-        return ShipmentEvent.class;
-    }
-
     //Overriding base method here, as it marks empty results as an error, meaning we can't use switchOnEmpty()
     @Override
     public Mono<ShipmentEvent> findById(UUID id) {

--- a/src/main/java/org/dcsa/tnt/service/impl/TransportEventServiceImpl.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/TransportEventServiceImpl.java
@@ -20,11 +20,6 @@ public class TransportEventServiceImpl extends ExtendedBaseServiceImpl<Transport
         return transportEventRepository;
     }
 
-    @Override
-    public Class<TransportEvent> getModelClass() {
-        return TransportEvent.class;
-    }
-
     //Overriding base method here, as it marks empty results as an error, meaning we can't use switchOnEmpty()
     @Override
     public Mono<TransportEvent> findById(UUID id) {


### PR DESCRIPTION
Remove some redundant code + call `create` rather than `save` when creating events.  The difference is currently only theoretical but this is more future proof.