### PR TITLE
Rewrite TNT's subscription system to use the new model

### DIFF
--- a/.github/workflows/microservices.yml
+++ b/.github/workflows/microservices.yml
@@ -62,3 +62,4 @@ jobs:
         OAuthTokenUri: https://dcsa.eu.auth0.com/oauth/token
         API_ROOT_URI: http://localhost:9090/v2
         CALLBACK_URI: http://172.17.0.1:4567
+        DCSA_API_VALIDATOR_MAY_USE_POST_EVENTS_ENDPOINT: true

--- a/.github/workflows/microservices.yml
+++ b/.github/workflows/microservices.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: dcsaorg/DCSA-Information-Model
-        ref: master
+        ref: new-subscription-model
         path: DCSA-Information-Model
 
     - name: Run the TNT microservice plus database
@@ -43,7 +43,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: dcsaorg/DCSA-API-Validator
-        ref: master
+        ref: update-tnt-tests
         token: ${{ secrets.REPO_ACCESS_PAT }}
         path: DCSA-API-Validator
 

--- a/src/main/java/org/dcsa/tnt/controller/EventSubscriptionTOController.java
+++ b/src/main/java/org/dcsa/tnt/controller/EventSubscriptionTOController.java
@@ -16,6 +16,7 @@ import org.dcsa.core.exception.UpdateException;
 import org.dcsa.core.extendedrequest.ExtendedParameters;
 import org.dcsa.core.extendedrequest.ExtendedRequest;
 import org.dcsa.tnt.model.EventSubscription;
+import org.dcsa.tnt.model.transferobjects.EventSubscriptionSecretUpdateTO;
 import org.dcsa.tnt.model.transferobjects.EventSubscriptionTO;
 import org.dcsa.tnt.service.EventSubscriptionTOService;
 import org.springframework.data.r2dbc.dialect.R2dbcDialect;
@@ -108,6 +109,12 @@ public class EventSubscriptionTOController extends BaseController<EventSubscript
             return Mono.error(new UpdateException("Id in url does not match id in body"));
         }
         return eventSubscriptionTOService.update(eventSubscriptionTO);
+    }
+
+    @PutMapping("{id}/secret")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<Void> updateSecret(@PathVariable UUID id, @Valid @RequestBody EventSubscriptionSecretUpdateTO eventSubscriptionSecretUpdateTO) {
+        return eventSubscriptionTOService.updateSecret(id, eventSubscriptionSecretUpdateTO);
     }
 
     @DeleteMapping()

--- a/src/main/java/org/dcsa/tnt/controller/EventSubscriptionTOController.java
+++ b/src/main/java/org/dcsa/tnt/controller/EventSubscriptionTOController.java
@@ -95,7 +95,7 @@ public class EventSubscriptionTOController extends BaseController<EventSubscript
     @PostMapping(consumes = "application/json", produces = "application/json")
     @ResponseStatus(HttpStatus.CREATED)
     public Mono<EventSubscriptionTO> create(@Valid @RequestBody EventSubscriptionTO eventSubscriptionTO) {
-        if (eventSubscriptionTO.getId() != null) {
+        if (eventSubscriptionTO.getSubscriptionID() != null) {
             return Mono.error(new CreateException("Id not allowed when creating a new " + getType()));
         }
         return eventSubscriptionTOService.create(eventSubscriptionTO);
@@ -104,7 +104,7 @@ public class EventSubscriptionTOController extends BaseController<EventSubscript
     @PutMapping("{id}")
     @ResponseStatus(HttpStatus.OK)
     public Mono<EventSubscriptionTO> update(@PathVariable UUID id, @Valid @RequestBody EventSubscriptionTO eventSubscriptionTO) {
-        if (!Objects.equals(id, eventSubscriptionTO.getId())) {
+        if (!Objects.equals(id, eventSubscriptionTO.getSubscriptionID())) {
             return Mono.error(new UpdateException("Id in url does not match id in body"));
         }
         return eventSubscriptionTOService.update(eventSubscriptionTO);
@@ -113,7 +113,7 @@ public class EventSubscriptionTOController extends BaseController<EventSubscript
     @DeleteMapping()
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public Mono<Void> delete(@RequestBody EventSubscriptionTO eventSubscriptionTO) {
-        if (eventSubscriptionTO.getId() == null) {
+        if (eventSubscriptionTO.getSubscriptionID() == null) {
             return Mono.error(new DeleteException("No Id provided in " + getType() + " object"));
         }
         return eventSubscriptionTOService.delete(eventSubscriptionTO);

--- a/src/main/java/org/dcsa/tnt/model/Event.java
+++ b/src/main/java/org/dcsa/tnt/model/Event.java
@@ -1,15 +1,16 @@
 package org.dcsa.tnt.model;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.dcsa.core.model.AuditBase;
-import org.dcsa.core.model.GetId;
 import org.dcsa.tnt.model.enums.EventClassifierCode;
 import org.dcsa.tnt.model.enums.EventType;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.Transient;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
@@ -30,18 +31,15 @@ import java.util.UUID;
         @JsonSubTypes.Type(value = TransportEvent.class, name="TRANSPORT"),
         @JsonSubTypes.Type(value = ShipmentEvent.class, name="SHIPMENT")
 })
-public class Event extends AuditBase implements GetId<UUID> {
+public class Event extends AuditBase {
 
     @Id
-    @JsonProperty("eventID")
     @Column("event_id")
-    private UUID id;
+    private UUID eventID;
 
-    @JsonProperty("eventType")
     @Column("event_type")
     private EventType eventType;
 
-    @JsonProperty("eventDateTime")
     @Column("event_date_time")
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private OffsetDateTime eventDateTime;
@@ -51,12 +49,9 @@ public class Event extends AuditBase implements GetId<UUID> {
     @CreatedDate
     private OffsetDateTime eventCreatedDateTime;
 
-    @JsonProperty("eventClassifierCode")
     @Column("event_classifier_code")
     private EventClassifierCode eventClassifierCode;
 
-    @JsonProperty("eventTypeCode")
     @Column("event_type_code")
     private String eventTypeCode;
-
 }

--- a/src/main/java/org/dcsa/tnt/model/Event.java
+++ b/src/main/java/org/dcsa/tnt/model/Event.java
@@ -7,7 +7,9 @@ import org.dcsa.core.model.AuditBase;
 import org.dcsa.core.model.GetId;
 import org.dcsa.tnt.model.enums.EventClassifierCode;
 import org.dcsa.tnt.model.enums.EventType;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
@@ -43,6 +45,11 @@ public class Event extends AuditBase implements GetId<UUID> {
     @Column("event_date_time")
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private OffsetDateTime eventDateTime;
+
+    @Column("event_created_date_time")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    @CreatedDate
+    private OffsetDateTime eventCreatedDateTime;
 
     @JsonProperty("eventClassifierCode")
     @Column("event_classifier_code")

--- a/src/main/java/org/dcsa/tnt/model/Event.java
+++ b/src/main/java/org/dcsa/tnt/model/Event.java
@@ -31,7 +31,7 @@ import java.util.UUID;
         @JsonSubTypes.Type(value = TransportEvent.class, name="TRANSPORT"),
         @JsonSubTypes.Type(value = ShipmentEvent.class, name="SHIPMENT")
 })
-public class Event extends AuditBase {
+public class Event extends AuditBase implements Notification {
 
     @Id
     @Column("event_id")

--- a/src/main/java/org/dcsa/tnt/model/EventSubscription.java
+++ b/src/main/java/org/dcsa/tnt/model/EventSubscription.java
@@ -3,6 +3,8 @@ package org.dcsa.tnt.model;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.dcsa.tnt.model.base.AbstractEventSubscription;
+import org.dcsa.tnt.model.enums.SignatureMethod;
+import org.springframework.data.annotation.Transient;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
@@ -12,7 +14,7 @@ import java.util.UUID;
 @Table("event_subscription")
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class EventSubscription extends AbstractEventSubscription {
+public class EventSubscription extends AbstractEventSubscription implements EventSubscriptionState {
 
     @Column("retry_count")
     private Long retryCount = 0L;
@@ -23,6 +25,33 @@ public class EventSubscription extends AbstractEventSubscription {
     @Column("last_event_id")
     private UUID lastEventID;
 
+    @Column("last_bundle_size")
+    private Integer lastBundleSize;
+
+    @Column("last_status_message")
+    private String lastStatusMessage;
+
     @Column("last_event_date_created_date_time")
     private OffsetDateTime lastEventDateCreatedDateTime;
+
+    @Column("accumulated_retry_delay")
+    private Long accumulatedRetryDelay;
+
+    @Column("signature_method")
+    private SignatureMethod signatureMethod;
+
+    public byte[] getSigningKey() {
+        return secret;
+    }
+
+    public void copyInternalFieldsFrom(EventSubscription eventSubscription) {
+        this.retryCount = eventSubscription.retryCount;
+        this.retryAfter = eventSubscription.retryAfter;
+        this.lastEventID = eventSubscription.lastEventID;
+        this.lastBundleSize = eventSubscription.lastBundleSize;
+        this.lastStatusMessage = eventSubscription.lastStatusMessage;
+        this.lastEventDateCreatedDateTime = eventSubscription.lastEventDateCreatedDateTime;
+        this.accumulatedRetryDelay = eventSubscription.accumulatedRetryDelay;
+        this.signatureMethod = eventSubscription.signatureMethod;
+    }
 }

--- a/src/main/java/org/dcsa/tnt/model/EventSubscriptionState.java
+++ b/src/main/java/org/dcsa/tnt/model/EventSubscriptionState.java
@@ -1,0 +1,42 @@
+package org.dcsa.tnt.model;
+
+import org.dcsa.tnt.model.enums.SignatureMethod;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public interface EventSubscriptionState {
+
+    UUID getSubscriptionID();
+    String getCallbackUrl();
+    byte[] getSigningKey();
+    SignatureMethod getSignatureMethod();
+
+    Long getRetryCount();
+    void setRetryCount(Long retryCount);
+
+    Long getAccumulatedRetryDelay();
+    void setAccumulatedRetryDelay(Long accumulatedRetryDelay);
+
+    OffsetDateTime getRetryAfter();
+    void setRetryAfter(OffsetDateTime retryAfter);
+
+    Integer getLastBundleSize();
+    void setLastBundleSize(Integer lastBundleSize);
+
+    UUID getLastEventID();
+    void setLastEventID(UUID lastEventID);
+
+    OffsetDateTime getLastEventDateCreatedDateTime();
+    void setLastEventDateCreatedDateTime(OffsetDateTime lastEventDateCreatedDateTime);
+
+    String getLastStatusMessage();
+    void setLastStatusMessage(String lastStatusMessage);
+
+    default void resetFailureState() {
+        setRetryAfter(null);
+        setAccumulatedRetryDelay(null);
+        setRetryCount(0L);
+        setLastBundleSize(null);
+    }
+}

--- a/src/main/java/org/dcsa/tnt/model/Notification.java
+++ b/src/main/java/org/dcsa/tnt/model/Notification.java
@@ -1,0 +1,10 @@
+package org.dcsa.tnt.model;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public interface Notification {
+
+    UUID getEventID();
+    OffsetDateTime getEventCreatedDateTime();
+}

--- a/src/main/java/org/dcsa/tnt/model/base/AbstractEventSubscription.java
+++ b/src/main/java/org/dcsa/tnt/model/base/AbstractEventSubscription.java
@@ -1,6 +1,5 @@
 package org.dcsa.tnt.model.base;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.dcsa.core.model.AuditBase;
@@ -14,19 +13,15 @@ import java.util.UUID;
 public class AbstractEventSubscription extends AuditBase {
 
     @Id
-    @JsonProperty("subscriptionID")
     @Column("subscription_id")
-    private UUID id;
+    private UUID subscriptionID;
 
-    @JsonProperty("callbackUrl")
     @Column("callback_url")
     private String callbackUrl;
 
-    @JsonProperty("bookingReference")
     @Column("booking_reference")
     private String bookingReference;
 
-    @JsonProperty("equipmentReference")
     @Column("equipment_reference")
     private String equipmentReference;
 }

--- a/src/main/java/org/dcsa/tnt/model/base/AbstractEventSubscription.java
+++ b/src/main/java/org/dcsa/tnt/model/base/AbstractEventSubscription.java
@@ -1,11 +1,13 @@
 package org.dcsa.tnt.model.base;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.dcsa.core.model.AuditBase;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
 
+import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 @Data
@@ -24,4 +26,9 @@ public class AbstractEventSubscription extends AuditBase {
 
     @Column("equipment_reference")
     private String equipmentReference;
+
+    @Column("secret")
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    // Jackson encodes this in base64 by default
+    protected byte[] secret;
 }

--- a/src/main/java/org/dcsa/tnt/model/enums/SignatureMethod.java
+++ b/src/main/java/org/dcsa/tnt/model/enums/SignatureMethod.java
@@ -1,0 +1,44 @@
+package org.dcsa.tnt.model.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Getter
+public enum SignatureMethod {
+    HMAC_SHA256("sha256", "HmacSHA256", 64, 64),
+    PLAINTEXT_PASSWORD("plain", "", 1, 1024),
+    ;
+
+    private static final Map<String, SignatureMethod> BY_TAG;
+
+    @JsonValue
+    private final String signatureMethodTag;
+    private final String javaAlgorithmName;
+    private final int minKeyLength;
+    private final int maxKeyLength;
+
+    SignatureMethod(String signatureMethodTag, String javaAlgorithmName, int minKeyLength, int maxKeyLength) {
+        this.signatureMethodTag = signatureMethodTag;
+        this.javaAlgorithmName = javaAlgorithmName;
+        this.minKeyLength = minKeyLength;
+        this.maxKeyLength = maxKeyLength;
+    }
+
+    public static Optional<SignatureMethod> byTag(String signatureMethodTag) {
+        return Optional.ofNullable(BY_TAG.get(signatureMethodTag));
+    }
+
+    static {
+        SignatureMethod[] methods = SignatureMethod.values();
+        Map<String, SignatureMethod> map = new HashMap<>(methods.length);
+        for (SignatureMethod method : methods) {
+            map.put(method.getSignatureMethodTag(), method);
+        }
+        BY_TAG = Collections.unmodifiableMap(map);
+    }
+}

--- a/src/main/java/org/dcsa/tnt/model/transferobjects/EventSubscriptionSecretUpdateTO.java
+++ b/src/main/java/org/dcsa/tnt/model/transferobjects/EventSubscriptionSecretUpdateTO.java
@@ -1,0 +1,12 @@
+package org.dcsa.tnt.model.transferobjects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class EventSubscriptionSecretUpdateTO {
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    // Jackson encodes this in base64 by default
+    protected byte[] secret;
+}

--- a/src/main/java/org/dcsa/tnt/repository/EventSubscriptionRepository.java
+++ b/src/main/java/org/dcsa/tnt/repository/EventSubscriptionRepository.java
@@ -15,10 +15,10 @@ import java.util.UUID;
 
 public interface EventSubscriptionRepository extends ExtendedRepository<EventSubscription, UUID> {
 
-    @Query("SELECT callback_url FROM event_subscription es"
+    @Query("SELECT es.* FROM event_subscription es"
             + "  JOIN event_subscription_event_types eset ON (es.subscription_id = eset.subscription_id)"
             + " WHERE eset.event_type = :eventType AND (:equipmentReference IS NULL or es.equipment_reference = :equipmentReference)")
-    Flux<String> findSubscriptionsByFilters(@Param("eventType") EventType eventType, @Param("equipmentReference") String equipmentReference);
+    Flux<EventSubscription> findSubscriptionsByFilters(@Param("eventType") EventType eventType, @Param("equipmentReference") String equipmentReference);
 
     @Modifying
     @Query("INSERT INTO event_subscription_event_types (subscription_id, event_type)"

--- a/src/main/java/org/dcsa/tnt/service/EventSubscriptionService.java
+++ b/src/main/java/org/dcsa/tnt/service/EventSubscriptionService.java
@@ -1,10 +1,14 @@
 package org.dcsa.tnt.service;
 
 import org.dcsa.core.service.ExtendedBaseService;
+import org.dcsa.tnt.model.Event;
 import org.dcsa.tnt.model.EventSubscription;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
 public interface EventSubscriptionService extends ExtendedBaseService<EventSubscription, UUID> {
-
+    Mono<EventSubscription> emitNotification(EventSubscription eventSubscription,
+                                             Flux<? extends Event> events);
 }

--- a/src/main/java/org/dcsa/tnt/service/EventSubscriptionService.java
+++ b/src/main/java/org/dcsa/tnt/service/EventSubscriptionService.java
@@ -3,6 +3,7 @@ package org.dcsa.tnt.service;
 import org.dcsa.core.service.ExtendedBaseService;
 import org.dcsa.tnt.model.Event;
 import org.dcsa.tnt.model.EventSubscription;
+import org.dcsa.tnt.model.Notification;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -10,5 +11,5 @@ import java.util.UUID;
 
 public interface EventSubscriptionService extends ExtendedBaseService<EventSubscription, UUID> {
     Mono<EventSubscription> emitNotification(EventSubscription eventSubscription,
-                                             Flux<? extends Event> events);
+                                             Flux<? extends Notification> notifications);
 }

--- a/src/main/java/org/dcsa/tnt/service/EventSubscriptionTOService.java
+++ b/src/main/java/org/dcsa/tnt/service/EventSubscriptionTOService.java
@@ -3,12 +3,15 @@ package org.dcsa.tnt.service;
 import org.dcsa.core.extendedrequest.ExtendedRequest;
 import org.dcsa.core.service.BaseService;
 import org.dcsa.tnt.model.EventSubscription;
+import org.dcsa.tnt.model.transferobjects.EventSubscriptionSecretUpdateTO;
 import org.dcsa.tnt.model.transferobjects.EventSubscriptionTO;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
 public interface EventSubscriptionTOService extends BaseService<EventSubscriptionTO, UUID> {
 
     Flux<EventSubscriptionTO> findAllExtended(ExtendedRequest<EventSubscription> extendedRequest);
+    Mono<Void> updateSecret(UUID subscriptionID, EventSubscriptionSecretUpdateTO eventSubscriptionSecretUpdateTO);
 }

--- a/src/main/java/org/dcsa/tnt/service/impl/EventServiceImpl.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/EventServiceImpl.java
@@ -1,21 +1,28 @@
 package org.dcsa.tnt.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.dcsa.core.exception.NotFoundException;
 import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
-import org.dcsa.tnt.model.EquipmentEvent;
-import org.dcsa.tnt.model.Event;
-import org.dcsa.tnt.model.ShipmentEvent;
-import org.dcsa.tnt.model.TransportEvent;
+import org.dcsa.tnt.model.*;
 import org.dcsa.tnt.repository.EventRepository;
 import org.dcsa.tnt.repository.EventSubscriptionRepository;
 import org.dcsa.tnt.service.EventService;
-import org.dcsa.tnt.util.EventCallbackHandler;
+import org.dcsa.tnt.service.EventSubscriptionService;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
+import java.util.function.Supplier;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class EventServiceImpl extends ExtendedBaseServiceImpl<EventRepository, Event, UUID> implements EventService {
@@ -24,6 +31,9 @@ public class EventServiceImpl extends ExtendedBaseServiceImpl<EventRepository, E
     private final EquipmentEventServiceImpl equipmentEventService;
     private final EventSubscriptionRepository eventSubscriptionRepository;
     private final EventRepository eventRepository;
+    private final EventSubscriptionService eventSubscriptionService;
+    private final ThreadPoolTaskExecutor executor;
+    private final ReactiveTransactionManager transactionManager;
 
 
     @Override
@@ -42,30 +52,65 @@ public class EventServiceImpl extends ExtendedBaseServiceImpl<EventRepository, E
 
     @Override
     public Mono<Event> create(Event event) {
+        String equipmentReference;
+        if (event instanceof EquipmentEvent) {
+            equipmentReference = ((EquipmentEvent) event).getEquipmentReference();
+        } else {
+            equipmentReference = null;
+        }
+        Supplier<Flux<EventSubscription>> subscriptionFlux = () -> eventSubscriptionRepository.findSubscriptionsByFilters(event.getEventType(), equipmentReference);
+        Mono<Event> createEventMono;
+        if (event.getEventCreatedDateTime() == null) {
+            event.setEventCreatedDateTime(OffsetDateTime.now());
+        }
         switch (event.getEventType()) {
             case SHIPMENT:
-                return shipmentEventService.create((ShipmentEvent) event).doOnNext(
-                        e -> new EventCallbackHandler(
-                                eventSubscriptionRepository.findSubscriptionsByFilters(e.getEventType(),
-                                        null), e)
-                                .start()
-                ).cast(Event.class);
+                assert event instanceof ShipmentEvent;
+                createEventMono = shipmentEventService.create((ShipmentEvent) event).cast(Event.class);
+                break;
             case TRANSPORT:
-                return transportEventService.create((TransportEvent) event).doOnNext(
-                        e -> new EventCallbackHandler(
-                                eventSubscriptionRepository.findSubscriptionsByFilters(e.getEventType(),
-                                        null), e)
-                                .start()
-                ).cast(Event.class);
+                assert event instanceof TransportEvent;
+                createEventMono = transportEventService.create((TransportEvent) event).cast(Event.class);
+                break;
             case EQUIPMENT:
-                return equipmentEventService.create((EquipmentEvent) event).doOnNext(
-                        e -> new EventCallbackHandler(
-                                eventSubscriptionRepository.findSubscriptionsByFilters(e.getEventType(),
-                                e.getEquipmentReference()), e)
-                                .start()
-                ).cast(Event.class);
+                assert event instanceof EquipmentEvent;
+                createEventMono = equipmentEventService.create((EquipmentEvent) event).cast(Event.class);
+                break;
             default:
                 return Mono.error(new IllegalStateException("Unexpected value: " + event.getEventType()));
+        }
+        return createEventMono
+                .doOnNext(e -> executor.submit(ProcessEvents.of(transactionManager, eventSubscriptionService, subscriptionFlux, e)));
+    }
+
+    @Slf4j
+    @RequiredArgsConstructor(staticName = "of")
+    private static class ProcessEvents implements Runnable {
+        private final ReactiveTransactionManager transactionManager;
+        private final EventSubscriptionService eventSubscriptionService;
+        private final Supplier<Flux<EventSubscription>> eventSubscriptionSupplier;
+        private final Event notification;
+
+        public void run() {
+            List<Event> notifications = Collections.singletonList(notification);
+            TransactionalOperator transactionalOperator = TransactionalOperator.create(transactionManager);
+            try {
+                eventSubscriptionSupplier.get().concatMap(eventSubscriptionState ->
+                        // We want to commit each subscription independently to limit the consequences of a
+                        transactionalOperator.transactional(eventSubscriptionService.emitNotification(eventSubscriptionState, Flux.fromIterable(notifications)))
+                )
+                .count()
+                .block();
+            } catch (Throwable e) {
+                // The default exception handler for uncaught exceptions is to silently discard
+                // them.  We "improve" the situation by at least logging them but there is no
+                // point in re-throwing it (except for errors as one should never make an error
+                // "handled").
+                log.warn("Event submission failed", e);
+                if (e instanceof Error) {
+                    throw (Error)e;
+                }
+            }
         }
     }
 }

--- a/src/main/java/org/dcsa/tnt/service/impl/EventSubscriptionServiceImpl.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/EventSubscriptionServiceImpl.java
@@ -6,6 +6,7 @@ import org.dcsa.core.exception.UpdateException;
 import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.dcsa.tnt.model.Event;
 import org.dcsa.tnt.model.EventSubscription;
+import org.dcsa.tnt.model.Notification;
 import org.dcsa.tnt.model.enums.SignatureMethod;
 import org.dcsa.tnt.repository.EventSubscriptionRepository;
 import org.dcsa.tnt.service.EventSubscriptionService;
@@ -88,8 +89,8 @@ public class EventSubscriptionServiceImpl extends ExtendedBaseServiceImpl<EventS
 
     @Override
     public Mono<EventSubscription> emitNotification(EventSubscription eventSubscription,
-                                                    Flux<? extends Event> events) {
-        return notificationSignatureHandler.emitNotifications(eventSubscription, events)
+                                                    Flux<? extends Notification> notifications) {
+        return notificationSignatureHandler.emitNotifications(eventSubscription, notifications)
                 .flatMap(this::save);
     }
 }

--- a/src/main/java/org/dcsa/tnt/service/impl/EventSubscriptionServiceImpl.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/EventSubscriptionServiceImpl.java
@@ -1,12 +1,17 @@
 package org.dcsa.tnt.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.dcsa.core.exception.CreateException;
 import org.dcsa.core.exception.UpdateException;
 import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
+import org.dcsa.tnt.model.Event;
 import org.dcsa.tnt.model.EventSubscription;
+import org.dcsa.tnt.model.enums.SignatureMethod;
 import org.dcsa.tnt.repository.EventSubscriptionRepository;
 import org.dcsa.tnt.service.EventSubscriptionService;
+import org.dcsa.tnt.service.impl.config.NotificationServiceConfig;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.net.URI;
@@ -17,6 +22,9 @@ import java.util.UUID;
 @Service
 public class EventSubscriptionServiceImpl extends ExtendedBaseServiceImpl<EventSubscriptionRepository, EventSubscription, UUID> implements EventSubscriptionService {
     private final EventSubscriptionRepository eventSubscriptionRepository;
+    private final NotificationServiceConfig notificationServiceConfig;
+    private final NotificationSignatureHandler notificationSignatureHandler;
+
 
     @Override
     public EventSubscriptionRepository getRepository() {
@@ -24,13 +32,64 @@ public class EventSubscriptionServiceImpl extends ExtendedBaseServiceImpl<EventS
     }
 
     @Override
-    protected Mono<EventSubscription> preSaveHook(EventSubscription eventSubscription) {
+    protected Mono<EventSubscription> preCreateHook(EventSubscription eventSubscription) {
+        byte[] secret = eventSubscription.getSecret();
+        SignatureMethod signatureMethod;
+        if (eventSubscription.getSignatureMethod() == null) {
+            signatureMethod = notificationServiceConfig.getDefaultSignatureMethod();
+            eventSubscription.setSignatureMethod(signatureMethod);
+        } else {
+            signatureMethod = eventSubscription.getSignatureMethod();
+        }
+        if (secret == null || secret.length < 1) {
+            return Mono.error(new CreateException("Please provide a non-empty \"secret\" attribute"));
+        }
+        if (signatureMethod.getMinKeyLength() == signatureMethod.getMaxKeyLength()) {
+            if (secret.length != signatureMethod.getMinKeyLength()) {
+                if (secret.length  > 1 && secret.length - 1 == signatureMethod.getMinKeyLength()
+                        && Character.isSpaceChar(((int)secret[secret.length - 1]) & 0xff)) {
+                    return Mono.error(new CreateException("The secret provided in the \"secret\" attribute must be exactly "
+                            + signatureMethod.getMinKeyLength() + " bytes long (when deserialized).  Did you"
+                            + " accidentally include a trailing newline/space in the secret?"));
+                }
+                return Mono.error(new CreateException("The secret provided in the \"secret\" attribute must be exactly "
+                        + signatureMethod.getMinKeyLength() + " bytes long (when deserialized)"));
+            }
+        } else {
+            if (secret.length < signatureMethod.getMinKeyLength()) {
+                return Mono.error(new CreateException("The secret provided in the \"secret\" attribute must be at least "
+                        + signatureMethod.getMinKeyLength() + " bytes long (when deserialized)"));
+            }
+            if (secret.length > signatureMethod.getMaxKeyLength()) {
+                return Mono.error(new CreateException("The secret provided in the \"secret\" attribute must be at most "
+                        + signatureMethod.getMaxKeyLength() + " bytes long (when deserialized)"));
+            }
+        }
+        return checkCallbackUrl(eventSubscription);
+    }
+
+    @Override
+    protected Mono<EventSubscription> preUpdateHook(EventSubscription original, EventSubscription update) {
+        return checkCallbackUrl(update);
+    }
+
+    protected Mono<EventSubscription> checkCallbackUrl(EventSubscription eventSubscription) {
         // Ensure that the callback url at least looks valid.
         try {
             new URI(eventSubscription.getCallbackUrl());
         } catch (URISyntaxException e) {
             return Mono.error(new UpdateException("callbackUrl is invalid: " + e.getLocalizedMessage()));
         }
-        return super.preSaveHook(eventSubscription);
+        return Mono.just(eventSubscription);
+    }
+
+
+
+
+    @Override
+    public Mono<EventSubscription> emitNotification(EventSubscription eventSubscription,
+                                                    Flux<? extends Event> events) {
+        return notificationSignatureHandler.emitNotifications(eventSubscription, events)
+                .flatMap(this::save);
     }
 }

--- a/src/main/java/org/dcsa/tnt/service/impl/NotificationSignatureHandler.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/NotificationSignatureHandler.java
@@ -1,0 +1,374 @@
+package org.dcsa.tnt.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.dcsa.tnt.model.Event;
+import org.dcsa.tnt.model.EventSubscriptionState;
+import org.dcsa.tnt.model.enums.SignatureMethod;
+import org.dcsa.tnt.service.impl.config.NotificationServiceConfig;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationSignatureHandler {
+
+    private static final String SIGNATURE_HEADER_NAME = "Notification-Signature";
+    private static final String SUBSCRIPTION_ID_HEADER_NAME = "Subscription-ID";
+    private static final Map<SignatureMethod, SignatureFunction> SIGNATURE_FUNCTION_MAP = new HashMap<>();
+
+    static {
+        declareKeyFunction(PlainPasswordFunction.INSTANCE);
+        declareKeyFunction(HMacFunction.of(SignatureMethod.HMAC_SHA256));
+    }
+
+    private static void declareKeyFunction(SignatureFunction signatureFunction) {
+        SIGNATURE_FUNCTION_MAP.put(signatureFunction.getSignatureMethod(), signatureFunction);
+    }
+
+    private final NotificationServiceConfig notificationServiceConfig;
+
+    private final ObjectMapper objectMapper;
+
+    public SignatureFunction getSignatureFunction(SignatureMethod signatureMethod) {
+        return SIGNATURE_FUNCTION_MAP.get(signatureMethod);
+    }
+
+    public <T> Mono<SignatureResult<T>> verifyRequest(ServerHttpRequest request, String expectedSubscriptionID, byte[] key, Class<T> type) {
+        List<String> signatureValues = request.getHeaders().get(SIGNATURE_HEADER_NAME);
+        if (signatureValues == null || signatureValues.size() != 1) {
+            SignatureResult<T> responsePayload;
+            if (signatureValues == null || signatureValues.isEmpty()) {
+                responsePayload = SignatureResult.of("Invalid; Missing " + SIGNATURE_HEADER_NAME + " header");
+            } else {
+                responsePayload = SignatureResult.of("Invalid; Ambiguous " + SIGNATURE_HEADER_NAME + " header");
+            }
+            return Mono.just(responsePayload);
+        }
+        String signatureLine = signatureValues.get(0).trim();
+        int equalIndex = signatureLine.indexOf('=');
+        if (equalIndex < 1) {
+            return Mono.just(SignatureResult.of("Invalid; " + SIGNATURE_HEADER_NAME + " should use \"<signature-type>=<signature-here>\""));
+        }
+        String signatureType = signatureLine.substring(0, equalIndex).toLowerCase();
+        String signaturePart = signatureLine.substring(equalIndex + 1);
+        SignatureMethod signatureMethod = SignatureMethod.byTag(signatureType).orElse(null);
+        if (signatureMethod == null) {
+            return Mono.just(SignatureResult.of("Invalid; The signature type \"" + signatureType
+                    + "\" in " + SIGNATURE_HEADER_NAME + " is invalid or not supported"));
+        }
+        SignatureFunction signatureFunction = getSignatureFunction(signatureMethod);
+        if (key.length < signatureFunction.getMinKeyLength() || key.length > signatureFunction.getMaxKeyLength()) {
+            return Mono.just(SignatureResult.of("Invalid; The key does not match the signature algorithm in "
+                    + SIGNATURE_HEADER_NAME));
+        }
+        byte[] providedSignature;
+        try {
+            providedSignature = signatureFunction.parseSignature(signaturePart);
+        } catch (Exception e) {
+            return Mono.just(SignatureResult.of("Invalid; The decoding failed of the signature in "
+                    + SIGNATURE_HEADER_NAME + ": " + e.getMessage()));
+        }
+        List<String> subscriptionIDs = request.getHeaders().get("Subscription-ID");
+        if (subscriptionIDs == null || subscriptionIDs.size() != 1) {
+            SignatureResult<T> responsePayload;
+            if (subscriptionIDs == null || subscriptionIDs.isEmpty()) {
+                responsePayload = SignatureResult.of("Invalid; Missing " + SUBSCRIPTION_ID_HEADER_NAME + " header");
+            } else {
+                responsePayload = SignatureResult.of("Invalid; Ambiguous " + SUBSCRIPTION_ID_HEADER_NAME + " header");
+            }
+            return Mono.just(responsePayload);
+        }
+        if (!Objects.equals(subscriptionIDs.get(0).trim(), expectedSubscriptionID)) {
+            return Mono.just(SignatureResult.of("Invalid; Subscription-ID provided in " + SUBSCRIPTION_ID_HEADER_NAME
+                    + " did not match the expected Subscription-ID"));
+        }
+        return request.getBody().map(DataBuffer::asByteBuffer).collectList()
+                .flatMap(buffers -> {
+                    byte[] payload;
+                    if (buffers.size() == 1) {
+                        ByteBuffer buffer = buffers.get(0);
+                        payload = new byte[buffer.remaining()];
+                        buffer.get(payload);
+                    } else {
+                        int total = buffers.stream().map(ByteBuffer::remaining).reduce(0, Integer::sum);
+                        payload = new byte[total];
+                        ByteBuffer combined = ByteBuffer.wrap(payload);
+                        for (ByteBuffer subBuffer : buffers) {
+                            combined.put(subBuffer);
+                        }
+                    }
+                    SignatureResult<T> s;
+                    try {
+                        if (signatureFunction.verifySignature(key, payload, providedSignature)) {
+                            s = SignatureResult.of("Valid",
+                                    true,
+                                    signatureFunction.getSignatureMethod(),
+                                    objectMapper.readValue(payload, type)
+                            );
+                        } else {
+                            s = SignatureResult.of("Invalid; The signature provided in " + SIGNATURE_HEADER_NAME
+                                    + " did not match the payload (or the wrong key was used)", signatureFunction.getSignatureMethod());
+                        }
+                    } catch (Exception e) {
+                        return Mono.error(e);
+                    }
+                    return Mono.just(s);
+                });
+    }
+
+    public <T extends EventSubscriptionState> Mono<T> emitNotifications(T eventSubscriptionState,
+                                                                        Flux<? extends Event> events) {
+        int bundleSize = eventSubscriptionState.getLastBundleSize() != null
+                ? eventSubscriptionState.getLastBundleSize()
+                : notificationServiceConfig.getDefaultBundleSize();
+        URI uri;
+        String callbackUrl = eventSubscriptionState.getCallbackUrl();
+        try {
+            uri = new URI(callbackUrl);
+        } catch (URISyntaxException e) {
+            IllegalArgumentException out = new IllegalArgumentException("Could not parse callback URL: " + callbackUrl, e);
+            log.error(out.getLocalizedMessage(), e);
+            throw out;
+        }
+        SignatureFunction signatureFunction = getSignatureFunction(eventSubscriptionState.getSignatureMethod());
+        if (signatureFunction == null) {
+            UnsupportedOperationException e = new UnsupportedOperationException("The subscription wanted signature "
+                    + eventSubscriptionState.getSignatureMethod() + " but it is not known/supported!");
+            log.error(e.getLocalizedMessage(), e);
+            throw e;
+        }
+        WebClient webClient = WebClient.builder()
+                // TODO: Disable redirects
+                // TODO: Set time outs
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+        log.info("Extracting up to " + bundleSize + " events to submit to " + eventSubscriptionState.getCallbackUrl());
+        return events.limitRequest(bundleSize)
+                .collectList()
+                .flatMap(notificationBundle -> {
+                    if (notificationBundle.isEmpty()) {
+                        return Mono.just(eventSubscriptionState);
+                    }
+                    OffsetDateTime earliest = eventSubscriptionState.getLastEventDateCreatedDateTime();
+                    UUID latestUUID = notificationBundle.get(notificationBundle.size() - 1).getId();
+                    byte[] bundleSerialized;
+                    log.info("Submitting " + notificationBundle.size() + " notification(s) to subscription " + eventSubscriptionState.getCallbackUrl());
+
+                    for (Event event : notificationBundle) {
+                        OffsetDateTime eventCreatedDateTime = event.getEventCreatedDateTime();
+                        if (earliest != null && eventCreatedDateTime.isBefore(earliest)) {
+                            throw new IllegalArgumentException("Events must be sorted by eventCreatedDateTime but was not!");
+                        }
+                        earliest = eventCreatedDateTime;
+                    }
+                    try {
+                        bundleSerialized = objectMapper.writeValueAsBytes(notificationBundle);
+                    } catch (JsonProcessingException e) {
+                        throw new IllegalArgumentException("Cannot serialize events", e);
+                    }
+                    final OffsetDateTime lastEventCreatedDateTime = earliest;
+                    final String signatureHeaderValue;
+                    try {
+                        signatureHeaderValue = signatureFunction.computeSignatureString(
+                                eventSubscriptionState.getSigningKey(),
+                                bundleSerialized
+                        );
+                    } catch (Exception e) {
+                        return Mono.error(e);
+                    }
+                    return webClient.post()
+                            .uri(uri)
+                            .header(SIGNATURE_HEADER_NAME, signatureHeaderValue)
+                            .header(SUBSCRIPTION_ID_HEADER_NAME, String.valueOf(eventSubscriptionState.getSubscriptionID()))
+                            .bodyValue(bundleSerialized)
+                            .exchangeToMono(clientResponse -> {
+                                int responseCode = clientResponse.rawStatusCode();
+                                String statusMessage;
+                                if (responseCode >= 200 && responseCode < 300) {
+                                    eventSubscriptionState.resetFailureState();
+                                    eventSubscriptionState.setLastEventID(latestUUID);
+                                    eventSubscriptionState.setLastEventDateCreatedDateTime(lastEventCreatedDateTime);
+                                    statusMessage = "Success. Sent " + notificationBundle.size()  + " notification(s), response code "
+                                            + responseCode;
+                                    log.debug("Notification sent to " + callbackUrl + ", it replied with: "
+                                            + responseCode + " (status: " + statusMessage + ")");
+                                } else {
+                                    ClientResponse.Headers headers = clientResponse.headers();
+                                    List<String> retryAfterHeader = headers.header("Retry-After");
+                                    OffsetDateTime nextAttempt = null;
+                                    boolean delayRequestedBySubscriber = false;
+                                    boolean respectRetryAfter = false;
+                                    eventSubscriptionState.setRetryCount(eventSubscriptionState.getRetryCount() + 1);
+                                    if (retryAfterHeader.size() == 1) {
+                                        nextAttempt = parseRetryAfterHeader(callbackUrl, retryAfterHeader.get(0));
+                                        delayRequestedBySubscriber = nextAttempt != null;
+                                    } else if (!retryAfterHeader.isEmpty()) {
+                                        log.debug(callbackUrl + " returned multiple Retry-After headers; ignoring them all");
+                                    }
+                                    switch (responseCode) {
+                                        case 413: // Payload too large
+                                            eventSubscriptionState.setLastBundleSize(Math.max(bundleSize / 2, 1));
+                                            respectRetryAfter = true;
+                                            // On a Payload too large, we retry "immediately" if we can reduce the size
+                                            // and the subscriber did not ask for a delay.
+                                            if (!delayRequestedBySubscriber && bundleSize > 1) {
+                                                // Keep the original delay in case the reduced request fails.
+                                                statusMessage = "Payload was too large (HTTP 429); retrying soon with a smaller payload";
+                                            } else if (bundleSize == 1) {
+                                                statusMessage = "Payload was too large (HTTP 429) but we cannot reduce the bundle size";
+                                            } else {
+                                                statusMessage = "Payload was too large (HTTP 429); retrying later (delay requested by subscriber)";
+                                            }
+                                            break;
+                                        case 503:
+                                            respectRetryAfter = true;
+                                            if (delayRequestedBySubscriber) {
+                                                statusMessage = "Subscriber was unavailable (HTTP 503) and provided a valid Retry-After header";
+                                            } else {
+                                                statusMessage = "Subscriber was unavailable (HTTP 503) without a (valid) Retry-After."
+                                                        + " Using back off strategy for delay";
+                                            }
+                                            break;
+                                        case 429:
+                                            respectRetryAfter = true;
+                                            if (delayRequestedBySubscriber) {
+                                                statusMessage = "Subscriber found us too persistent (HTTP 429) and provided a Valid Retry-After header.";
+                                            } else {
+                                                statusMessage = "Subscriber found us too persistent (HTTP 429) but did not provide a (valid) Retry-After."
+                                                        + " Using back off strategy for delay";
+                                            }
+                                            break;
+                                        case 301:
+                                        case 302:
+                                        case 307:
+                                        case 308:
+                                            statusMessage = "Subscriber responded with a redirection (HTTP " + responseCode + "), but we do not support redirects. Subscriber should update their subscription instead";
+                                            break;
+                                        case 400:
+                                            statusMessage = "Subscriber rejected the response as malformed (HTTP " + responseCode + "). Could be a bug at subscriber or in client";
+                                            break;
+                                        case 401:
+                                            statusMessage = "Subscriber rejected the payload due to missing / invalid Authentication (HTTP 401).  Might need a Secret reset";
+                                            break;
+                                        case 403:
+                                            statusMessage = "Subscriber rejected the payload (HTTP 403)";
+                                            break;
+                                        default:
+                                            if (responseCode < 400) {
+                                                statusMessage = "Subscriber responded with cache code or an unknown redirection code (HTTP " + responseCode + ")!?";
+                                            } else if (responseCode < 500) {
+                                                statusMessage = "Subscriber rejected message suggesting a client error (HTTP " + responseCode + ")";
+                                            } else {
+                                                statusMessage = "Subscriber was unavailable (HTTP " + responseCode + ")";
+                                            }
+                                            break;
+                                    }
+                                    if (!respectRetryAfter || nextAttempt == null) {
+                                        nextAttempt = computeNextDelay(eventSubscriptionState);
+                                    }
+                                    eventSubscriptionState.setRetryAfter(nextAttempt);
+                                    log.debug("Notification for " + callbackUrl + " failed, it replied with: "
+                                            + responseCode + ": Will retry after " + nextAttempt + " (status: "
+                                            + statusMessage + ")");
+                                }
+                                eventSubscriptionState.setLastStatusMessage(statusMessage);
+                                return Mono.just(eventSubscriptionState);
+                            });
+                });
+    }
+
+    private OffsetDateTime parseRetryAfterHeader(String callbackUrl, String retryAfterRaw) {
+        OffsetDateTime parsedDateTime = null;
+
+        if (!retryAfterRaw.isEmpty() && Character.isDigit(retryAfterRaw.charAt(0))) {
+            try {
+                long delay = Long.parseLong(retryAfterRaw);
+                parsedDateTime = OffsetDateTime.now().plusSeconds(delay);
+            } catch (NumberFormatException e) {
+                log.debug(callbackUrl + " returned invalid Retry-After header (delay-variant); ignoring");
+            }
+        } else {
+            try {
+                parsedDateTime = OffsetDateTime.parse(retryAfterRaw, DateTimeFormatter.RFC_1123_DATE_TIME);
+            } catch (DateTimeParseException e) {
+                log.debug(callbackUrl + " returned invalid Retry-After header (date-variant); ignoring");
+            }
+        }
+        return parsedDateTime;
+    }
+
+    private OffsetDateTime computeNextDelay(EventSubscriptionState eventSubscriptionState) {
+        Long delaySeconds = eventSubscriptionState.getAccumulatedRetryDelay();
+        long limit = notificationServiceConfig.getMaxRetryAfterDelay().toSeconds();
+        if (delaySeconds == null) {
+            delaySeconds = notificationServiceConfig.getMinRetryAfterDelay().toSeconds();
+        } else {
+            delaySeconds *= 2;
+        }
+        if (delaySeconds >= limit) {
+            delaySeconds = limit;
+        }
+        eventSubscriptionState.setAccumulatedRetryDelay(delaySeconds);
+        return OffsetDateTime.now().plusSeconds(delaySeconds);
+    }
+
+    @Getter
+    private static class PlainPasswordFunction implements SignatureFunction {
+        static final SignatureFunction INSTANCE = new PlainPasswordFunction();
+
+        @Override
+        public SignatureMethod getSignatureMethod() {
+            return SignatureMethod.PLAINTEXT_PASSWORD;
+        }
+
+        @Override
+        public byte[] computeSignature(byte[] key, byte[] payload) {
+            return key;
+        }
+
+        @Override
+        public byte[] parseSignature(String value) {
+            return value.getBytes(StandardCharsets.UTF_8);
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor(staticName = "of")
+    private static class HMacFunction implements SignatureFunction {
+        private final SignatureMethod signatureMethod;
+
+        @SneakyThrows(NoSuchAlgorithmException.class)
+        @Override
+        public byte[] computeSignature(byte[] key, byte[] payload) throws InvalidKeyException {
+            String javaAlgorithmName = getJavaAlgorithmName();
+            Mac mac = Mac.getInstance(javaAlgorithmName);
+            mac.init(new SecretKeySpec(key, javaAlgorithmName));
+            return mac.doFinal(payload);
+        }
+
+    }
+}

--- a/src/main/java/org/dcsa/tnt/service/impl/NotificationSignatureHandler.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/NotificationSignatureHandler.java
@@ -174,7 +174,7 @@ public class NotificationSignatureHandler {
                         return Mono.just(eventSubscriptionState);
                     }
                     OffsetDateTime earliest = eventSubscriptionState.getLastEventDateCreatedDateTime();
-                    UUID latestUUID = notificationBundle.get(notificationBundle.size() - 1).getId();
+                    UUID latestUUID = notificationBundle.get(notificationBundle.size() - 1).getEventID();
                     byte[] bundleSerialized;
                     log.info("Submitting " + notificationBundle.size() + " notification(s) to subscription " + eventSubscriptionState.getCallbackUrl());
 

--- a/src/main/java/org/dcsa/tnt/service/impl/NotificationSignatureHandler.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/NotificationSignatureHandler.java
@@ -39,6 +39,7 @@ public class NotificationSignatureHandler {
 
     private static final String SIGNATURE_HEADER_NAME = "Notification-Signature";
     private static final String SUBSCRIPTION_ID_HEADER_NAME = "Subscription-ID";
+    private static final String API_VERSION_HEADER_NAME = "API-Version";
     private static final Map<SignatureMethod, SignatureFunction> SIGNATURE_FUNCTION_MAP = new HashMap<>();
 
     static {
@@ -205,6 +206,7 @@ public class NotificationSignatureHandler {
                             .uri(uri)
                             .header(SIGNATURE_HEADER_NAME, signatureHeaderValue)
                             .header(SUBSCRIPTION_ID_HEADER_NAME, String.valueOf(eventSubscriptionState.getSubscriptionID()))
+                            .header(API_VERSION_HEADER_NAME, notificationServiceConfig.getApiSpecificationVersion())
                             .bodyValue(bundleSerialized)
                             .exchangeToMono(clientResponse -> {
                                 HttpStatus httpStatus = clientResponse.statusCode();

--- a/src/main/java/org/dcsa/tnt/service/impl/SignatureFunction.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/SignatureFunction.java
@@ -1,0 +1,37 @@
+package org.dcsa.tnt.service.impl;
+
+import org.apache.commons.codec.binary.Hex;
+import org.dcsa.tnt.model.enums.SignatureMethod;
+
+import java.security.MessageDigest;
+
+public interface SignatureFunction {
+    SignatureMethod getSignatureMethod();
+
+    default String getJavaAlgorithmName() {
+        return getSignatureMethod().getJavaAlgorithmName();
+    }
+
+    byte[] computeSignature(byte[] key, byte[] payload) throws Exception;
+
+    default int getMinKeyLength() {
+        return getSignatureMethod().getMinKeyLength();
+    }
+    default int getMaxKeyLength() {
+        return getSignatureMethod().getMaxKeyLength();
+    }
+
+    default byte[] parseSignature(String value) throws Exception {
+        return Hex.decodeHex(value);
+    }
+
+    default String computeSignatureString(byte[] key, byte[] payload) throws Exception {
+        byte[] signature = this.computeSignature(key, payload);
+        return Hex.encodeHexString(signature);
+    }
+
+    default boolean verifySignature(byte[] key, byte[] payload, byte[] providedSignature) throws Exception {
+        byte[] computedSignature = computeSignature(key, payload);
+        return MessageDigest.isEqual(computedSignature, providedSignature);
+    }
+}

--- a/src/main/java/org/dcsa/tnt/service/impl/SignatureResult.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/SignatureResult.java
@@ -1,0 +1,21 @@
+package org.dcsa.tnt.service.impl;
+
+import lombok.Data;
+import org.dcsa.tnt.controller.EventSubscriptionTOController;
+import org.dcsa.tnt.model.enums.SignatureMethod;
+
+@Data(staticConstructor = "of")
+public class SignatureResult<T> {
+    private final String result;
+    private final boolean valid;
+    private final SignatureMethod signatureMethod;
+    private final T parsed;
+
+    public static <T> SignatureResult<T> of(String result) {
+        return of(result, null);
+    }
+
+    public static <T> SignatureResult<T> of(String result, SignatureMethod signatureMethod) {
+        return of(result, false, signatureMethod, null);
+    }
+}

--- a/src/main/java/org/dcsa/tnt/service/impl/config/NotificationServiceConfig.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/config/NotificationServiceConfig.java
@@ -31,6 +31,9 @@ public class NotificationServiceConfig {
 
     private SignatureMethod defaultSignatureMethod;
 
+    @Value("${dcsa.specification.version:N/A}")
+    private String apiSpecificationVersion;
+
     @Autowired
     void initializeDefaultSignatureMethod(@Value("${dcsa.EventNotificationService.defaultSignatureMethod:sha256}") String defaultSignatureMethod) {
         Optional<SignatureMethod> signatureMethodOptional = SignatureMethod.byTag(defaultSignatureMethod);

--- a/src/main/java/org/dcsa/tnt/service/impl/config/NotificationServiceConfig.java
+++ b/src/main/java/org/dcsa/tnt/service/impl/config/NotificationServiceConfig.java
@@ -1,0 +1,47 @@
+package org.dcsa.tnt.service.impl.config;
+
+import lombok.Getter;
+import org.dcsa.tnt.model.enums.SignatureMethod;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
+import org.springframework.context.annotation.Configuration;
+
+import javax.validation.constraints.Min;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Getter
+@Configuration
+@ConfigurationProperties(prefix = "dcsa.event-notification-service")
+public class NotificationServiceConfig {
+
+    @Min(1)
+    private int defaultBundleSize = 100;
+
+    @DurationUnit(ChronoUnit.MINUTES)
+    private Duration minRetryAfterDelay = Duration.of(60, ChronoUnit.SECONDS);
+
+    @DurationUnit(ChronoUnit.MINUTES)
+    private Duration maxRetryAfterDelay = Duration.of(24, ChronoUnit.HOURS);
+
+    private SignatureMethod defaultSignatureMethod;
+
+    @Autowired
+    void initializeDefaultSignatureMethod(@Value("${dcsa.EventNotificationService.defaultSignatureMethod:sha256}") String defaultSignatureMethod) {
+        Optional<SignatureMethod> signatureMethodOptional = SignatureMethod.byTag(defaultSignatureMethod);
+        if (signatureMethodOptional.isEmpty()) {
+            String methods = Arrays.stream(SignatureMethod.values())
+                    .map(SignatureMethod::getSignatureMethodTag)
+                    .sorted()
+                    .collect(Collectors.joining(", "));
+            throw new IllegalArgumentException("Unknown signature listed in dcsa.EventNotificationService.defaultSignatureMethod: \""
+                    + defaultSignatureMethod + "\". Please choose one of: " + methods );
+        }
+        this.defaultSignatureMethod = signatureMethodOptional.get();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,6 +43,10 @@ spring:
   webflux:
     base-path: /v2
 
+dcsa:
+  specification:
+    version: 2.1.0
+
 auth0:
   audience: localhost
   enabled: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -62,5 +62,5 @@ server:
 
 logging:
   level:
-    dk: DEBUG
+    org.dcsa: DEBUG
 


### PR DESCRIPTION
Rewrite notification submission to use new Subscription model

This is the first step towards the new subscription model (or just signing of notifications in general).  To keep things simple, retry     logic (etc.) has been omitted for now but it definitely a missing piece.
