### PR TITLE
DDT-74 Add index.html for k8s readiness probe

### DIFF
--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<title>DCSA TNT dummy index</title>
+
+</head>
+<p>This is used from kubernetes readyness probe to test if the application is up</p>
+<body>
+</body>
+</html>


### PR DESCRIPTION
This is used from kubernetes readyness probe to test if the application is up