### PR TITLE
DDT-248 Use spring actuator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,11 @@
 			<artifactId>dcsa_event_core</artifactId>
 			<version>${dcsa.events.version}${dcsa.event.tag}${dcsa.artifacttype}</version>
 		</dependency>
-	</dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId> 
+			<artifactId>spring-boot-starter-actuator</artifactId> 
+		</dependency>
+	</dependencies>	
 
 	<build>
 		<plugins>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -49,7 +49,7 @@ dcsa:
 
 auth0:
   audience: localhost
-  enabled: true
+  enabled: false
 
 springdoc:
   api-docs:
@@ -67,4 +67,14 @@ server:
 logging:
   level:
     org.dcsa: DEBUG
+    
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -49,7 +49,7 @@ dcsa:
 
 auth0:
   audience: localhost
-  enabled: false
+  enabled: true
 
 springdoc:
   api-docs:


### PR DESCRIPTION
for liveness/readiness test.
Only the health endpoint have been enabled.

To use hit the endpoint /v2/actuator/health
You will get back a http 200 and
{
    "status": "UP",
    "groups": [
        "liveness",
        "readiness"
    ]
}